### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Cypress Tests
 
 on:
   push:
-    branches: [master, feature/ci]
+    branches: [master]
 
   pull_request:
     branches: [master]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Cypress Tests
 
 on:
   push:
-    branches: [master]
+    branches: [master, feature/ci]
 
   pull_request:
     branches: [master]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: Cypress Tests
+
+on:
+  push:
+    branches: [master]
+
+  pull_request:
+    branches: [master]
+
+  workflow_dispatch:
+
+jobs:
+  cypress-run-chrome:
+    runs-on: ubuntu-latest
+    container: cypress/included:7.6.0
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Run Cypress
+        uses: cypress-io/github-action@v2
+        with:
+          browser: chrome
+
+  cypress-run-electron:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Run Cypress
+        uses: cypress-io/github-action@v2
+        with:
+          start: npm run test


### PR DESCRIPTION
This is by far the easiest of the two branches to talk through the changes for.

I have added a CI pipeline using GitHub actions. This is all achieved via a `.yml` file located in the `.github/workflows` folder, in this case `ci.yml`.

The pipeline has 3 triggers:
1. A push to the `master` branch - this will run the pipeline against the `master` branch
2. Opening a pull request to the `master` branch (or pushing files to an open PR to `master`) - this will run the pipeline against the branch to be merged
3. A manual trigger - this allows a choice of branch; achieved by using the `workflow_dispatch` trigger in the yml file (awful name, but that's what it is called)

There are 2 jobs in the pipeline, which run in parallel.
**_cypress-run-chrome_**
As the name suggests, this runs the Cypress test suite in Chrome. An Ubuntu virtual environment is set up (`runs-on: ubuntu-latest`) and a Cypress Docker container is downloaded & started (`container: cypress/included:7.6.0`). This is an official Cypress Docker container, not something I have set up. The repo is then checked out, using the relevant branch according to the triggers above (`uses: actions/checkout@v2`) and the tests run via a Cypress-supplied GitHub actions method (`uses: cypress-io/github-action@v2`). In this case I specify a browser of Chrome as a parameter in that method (via the `with` keyword). Once the tests have run, GitHib automatically tears everything down - it does some cleanup, stops the container and kills any orphan processes before closing the virtual environment.

**_cypress-run-electron_**
It will come as no surprise to learn that this job runs the tests in Electron. This is simpler than the previous job because it doesn't use a Docker container (the Chrome job didn't really need to either but I showed it as an example). It uses the same steps and commands as the Chrome job (other than those relating to Docker) i.e. it starts an Unbuntu virtual environment, checks out the repo, runs the Cypress tests (this time without specifying a browser, which means it defaults to Electron) and then tears everything down.

This is a simple CI pipeline and there is more that could be added to it. For example, Cypress captures screenshots automatically if a test fails. However, the `screenshots` directory is within the virtual environment so wouldn't be accessible to us after the pipeline job has completed. We could add a step to each job to upload that `screenshots` directory if any of the tests fail so that the screenshots would be available as a zip file attached to that pipeline run. It's a pretty easy thing to add but I have kept this pipeline relatively simple for now.